### PR TITLE
Added the capability to play an automatic slideshow of images

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ The view settings are saved when you close a window or choose to view the next/p
 
 **SPACE** view next image within directory.
 
+**p** play slideshow of images in directory.
+
 **z** horiZontally maximises the window.
 
 **v** vertically maximises the window.


### PR DESCRIPTION
Hi Dan!
Here it is my little contribute to have an automatic slideshow in shufti. Just press "p" to play the slideshow. The slide time is hard-coded to **self.slideTime = 4000** (4 seconds), we should add some code to handle command line options. I hope to have command line options to start directly in fullscreen mode and to start slideshow immediately.
Sorry: you will see many line changed in the code, because my editor removed several blank spaces hidden in your code :-(